### PR TITLE
Remove explicit refresh interval from statusboard

### DIFF
--- a/app/views/statusboards/show.json.jbuilder
+++ b/app/views/statusboards/show.json.jbuilder
@@ -2,7 +2,6 @@ json.graph do
   json.title "Time Tracking"
   json.datasequences [@date_totals] do |sequence|
     json.title "Billable Hours"
-    json.refreshEveryNSeconds 3600
     json.datapoints sequence do |date_total|
       json.partial! date_total
     end

--- a/spec/requests/statusboard_spec.rb
+++ b/spec/requests/statusboard_spec.rb
@@ -24,7 +24,6 @@ describe "Statusboard" do
             "datasequences" => [
               {
                 "title" => "Billable Hours",
-                "refreshEveryNSeconds" => 3600,
                 "datapoints" => [
                   {
                     "title" => day_before.strftime('%A'),


### PR DESCRIPTION
We'll use the default (2 minutes).
