### PR TITLE
Add an email template for the weekly notifier.

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -10,6 +10,9 @@ class Notifier < ActionMailer::Base
     @internal_hours = user.internal_hours_last_week
     @total_hours = @client_hours + @internal_hours
 
+    @expected_client_hours = ENV["EXPECTED_WEEKLY_CLIENT_HOURS"].to_d
+    @expected_internal_hours = ENV["EXPECTED_WEEKLY_INTERNAL_HOURS"].to_d
+
     mail to: user.email
   end
 

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -1,4 +1,7 @@
 class Notifier < ActionMailer::Base
+  include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::NumberHelper
+
   default from: ENV["EMAIL_FROM"]
 
   def weekly_report(user)
@@ -9,4 +12,12 @@ class Notifier < ActionMailer::Base
 
     mail to: user.email
   end
+
+  private
+
+  def pluralize_hours(hours)
+    pluralize(number_with_precision(hours, precision: 1), "hour")
+  end
+
+  helper_method :pluralize_hours
 end

--- a/app/views/notifier/weekly_report.html.erb
+++ b/app/views/notifier/weekly_report.html.erb
@@ -40,7 +40,7 @@
         </td>
 
         <td>
-          <img src="https://chart.googleapis.com/chart?cht=p&chd=t:<%= @client_hours %>,<%= @internal_hours %>&chs=180x180&chdl=Client|Internal&chdlp=b"></img>
+          <img src="https://chart.googleapis.com/chart?cht=p&chd=t:<%= @client_hours %>,<%= @internal_hours %>|<%= @expected_client_hours %>,<%= @expected_internal_hours %>&chs=360x360&chdl=Client|Internal&chdlp=b&cht=pc&chdls=000000,24&chco=66cc00,004876,d9f2cc,bfd1dd" width="180" height="180" />
         </td>
       </tr>
 

--- a/app/views/notifier/weekly_report.html.erb
+++ b/app/views/notifier/weekly_report.html.erb
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+
+  <body>
+    <table>
+      <tr>
+        <td>
+          <p>
+            Hi <%= @user.name %>,
+          </p>
+        </td>
+      </tr>
+
+      <tr>
+        <td width="70%" height="180px" style="vertical-align: top;">
+          Your breakdown for last week:
+
+          <p>
+            <table width="50%">
+              <tr>
+                <td>Client</td>
+                <td><%= pluralize_hours(@client_hours) %></td>
+              </tr>
+              <tr>
+                <td>Internal</td>
+                <td><%= pluralize_hours(@internal_hours) %></td>
+              </tr>
+              <tr>
+                <td colspan=2><hr/></td>
+              </tr>
+              <tr>
+                <td>Total</td>
+                <td><%= pluralize_hours(@total_hours) %></td>
+              </tr>
+            </table>
+          </p>
+        </td>
+
+        <td>
+          <img src="https://chart.googleapis.com/chart?cht=p&chd=t:<%= @client_hours %>,<%= @internal_hours %>&chs=180x180&chdl=Client|Internal&chdlp=b"></img>
+        </td>
+      </tr>
+
+      <tr>
+        <td>
+          <p>
+            Happy tracking,<br/>
+            Hourglass ⏳
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/notifier/weekly_report.text.erb
+++ b/app/views/notifier/weekly_report.text.erb
@@ -1,6 +1,6 @@
 <%= @user.name %>,
 
-Last week, you spent <%= pluralize(number_with_precision(@client_hours, precision: 1), "hour") %> on client work and <%= pluralize(number_with_precision(@internal_hours, precision: 1), "hour") %> on internal work, for a total of <%= pluralize(number_with_precision(@total_hours, precision: 1), "hour") %>.
+Last week, you spent <%= pluralize_hours(@client_hours) %> on client work and <%= pluralize_hours(@internal_hours) %> on internal work, for a total of <%= pluralize_hours(@total_hours) %>.
 
 
 Happy tracking,

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -1,6 +1,10 @@
 # The address from which to send all application emails
 EMAIL_FROM: "Hourglass <hourglass@example.com>"
 
+# In a perfect world, how many hours per person per week
+EXPECTED_WEEKLY_CLIENT_HOURS: "32"
+EXPECTED_WEEKLY_INTERNAL_HOURS: "8"
+
 # Harvest credentials and configuration
 HARVEST_INTERNAL_CLIENT: "Internal" # The client in Harvest to consider internal
 HARVEST_PASSWORD: "secret"


### PR DESCRIPTION
It's super basic but includes a pie chart for a nice visualization of
how the time is split. We are using Google's static chart API which has
a big warning saying that it is deprecated but also saying they have no
plans to actually kill it. So it will hopefully be good for a while.

![weekly time report i 2015-04-13 17-17-09](https://cloud.githubusercontent.com/assets/7095/7125677/f17e8bcc-e200-11e4-82b2-aa22e2846167.png)

