### PR TITLE
Expand the Slack command's ability to parse dates/ranges

### DIFF
--- a/app/controllers/slacks_controller.rb
+++ b/app/controllers/slacks_controller.rb
@@ -4,12 +4,21 @@ class SlacksController < ApplicationController
                   when /today/
                     today = Date.current
                     today..today
+                  when /yesterday/
+                    yesterday = Date.yesterday
+                    yesterday..yesterday
                   when /this week/
                     today = Date.current
                     today.monday..today.sunday
+                  when /last week/
+                    a_week_ago = 1.week.ago.to_date
+                    a_week_ago.monday..a_week_ago.sunday
                   when /this month/
                     today = Date.current
                     today.beginning_of_month..today.end_of_month
+                  when /last month/
+                    a_month_ago = 1.month.ago.to_date
+                    a_month_ago.beginning_of_month..a_month_ago.end_of_month
                   else nil
                   end
 

--- a/app/controllers/slacks_controller.rb
+++ b/app/controllers/slacks_controller.rb
@@ -1,11 +1,15 @@
 class SlacksController < ApplicationController
   def show
-    today = Date.current
-
     @date_range = case params[:text]
-                  when /day/ then today..today
-                  when /week/ then today.monday..today.sunday
-                  when /month/ then today.beginning_of_month..today.end_of_month
+                  when /today/
+                    today = Date.current
+                    today..today
+                  when /this week/
+                    today = Date.current
+                    today.monday..today.sunday
+                  when /this month/
+                    today = Date.current
+                    today.beginning_of_month..today.end_of_month
                   else nil
                   end
 

--- a/spec/requests/slack_spec.rb
+++ b/spec/requests/slack_spec.rb
@@ -30,8 +30,8 @@ describe "Slack Command" do
       })
     end
 
-    it "returns the user's hours for the day" do
-      get "/slack", { text: "day", user_id: user.slack_id }
+    it "returns the user's hours for today" do
+      get "/slack", { text: "today", user_id: user.slack_id }
 
       expect(response.status).to eq(200)
       expect(response.body).to eq(<<-MSG.strip_heredoc)
@@ -42,8 +42,8 @@ describe "Slack Command" do
         MSG
     end
 
-    it "returns the user's hours for the week" do
-      get "/slack", { text: "week", user_id: user.slack_id }
+    it "returns the user's hours for this week" do
+      get "/slack", { text: "this week", user_id: user.slack_id }
 
       expect(response.status).to eq(200)
       expect(response.body).to eq(<<-MSG.strip_heredoc)
@@ -54,8 +54,8 @@ describe "Slack Command" do
         MSG
     end
 
-    it "returns the user's hours for the month" do
-      get "/slack", { text: "month", user_id: user.slack_id }
+    it "returns the user's hours for this month" do
+      get "/slack", { text: "this month", user_id: user.slack_id }
 
       expect(response.status).to eq(200)
       expect(response.body).to eq(<<-MSG.strip_heredoc)


### PR DESCRIPTION
These changes allow the `/hours` command to accept the following arguments:

```
today
yeserday
this week
last week
this month
last month
```