### PR TITLE
Refactor how the application deals with time ranges

### DIFF
--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -3,15 +3,12 @@ class Day < ActiveRecord::Base
 
   validates :date, presence: true, date: true, uniqueness: { scope: :user_id }
 
-  before_create :set_month_number
-  before_create :set_week_number
-
   def self.ensure(user:, date:, **attributes)
     find_or_initialize_by(user: user, date: date).update!(attributes)
   end
 
   def self.last_week
-    where(week_number: 1.week.ago.strftime("%G%V")).order(:date)
+    where(date: 1.week.ago.to_date.all_week).order(:date)
   end
 
   def self.for_timer_reminder(date: Date.current)
@@ -22,15 +19,5 @@ class Day < ActiveRecord::Base
       pto: false,
       timer_reminder_sent: false
     )
-  end
-
-  private
-
-  def set_month_number
-    self.month_number = date.strftime("%Y%m")
-  end
-
-  def set_week_number
-    self.week_number = date.strftime("%G%V")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   has_many :days, -> { order(:date) }, inverse_of: :user,
     dependent: :restrict_with_exception
-  has_many :months, -> { order(:number) }, inverse_of: :user,
+  has_many :months, -> { order(:year, :number) }, inverse_of: :user,
     dependent: :restrict_with_exception
 
   validates :name, presence: true

--- a/db/migrate/20150423135709_remove_week_and_month_numbers.rb
+++ b/db/migrate/20150423135709_remove_week_and_month_numbers.rb
@@ -1,0 +1,67 @@
+class RemoveWeekAndMonthNumbers < ActiveRecord::Migration
+  class Month < ActiveRecord::Base
+  end
+
+  class Day < ActiveRecord::Base
+  end
+
+  def up
+    remove_column :days, :month_number
+    remove_column :days, :week_number
+
+    add_column :months, :year, :integer
+    add_column :months, :temporary_number, :integer
+
+    Month.find_each do |month|
+      if match = month.number.match(/\A(\d{4})(\d{2})\z/)
+        year, temporary_number = match.captures.map(&:to_i)
+        month.update!(year: year, temporary_number: temporary_number)
+      else
+        raise "hell"
+      end
+    end
+
+    remove_column :months, :number
+
+    change_column_null :months, :year, false
+    change_column_null :months, :temporary_number, false
+
+    rename_column :months, :temporary_number, :number
+
+    add_index :months, :year
+    add_index :months, :number
+  end
+
+  def down
+    add_column :days, :month_number, :string
+    add_column :days, :week_number, :string
+
+    Day.find_each do |day|
+      month_number = day.date.strftime("%Y%m")
+      week_number = day.date.strftime("%G%V")
+      day.update!(month_number: month_number, week_number: week_number)
+    end
+
+    change_column_null :days, :month_number, false
+    change_column_null :days, :week_number, false
+
+    add_index :days, :month_number
+    add_index :days, :week_number
+
+    add_column :months, :temporary_number, :string
+
+    Month.find_each do |month|
+      temporary_number = "#{month.year}#{month.number.to_s.rjust(2, "0")}"
+      month.update!(temporary_number: temporary_number)
+    end
+
+    remove_column :months, :year
+    remove_column :months, :number
+
+    change_column_null :months, :temporary_number, false
+
+    rename_column :months, :temporary_number, :number
+
+    add_index :months, :number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150422171320) do
+ActiveRecord::Schema.define(version: 20150423135709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,8 +20,6 @@ ActiveRecord::Schema.define(version: 20150422171320) do
   create_table "days", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.uuid     "user_id",                                                     null: false
     t.date     "date",                                                        null: false
-    t.string   "month_number",                                                null: false
-    t.string   "week_number",                                                 null: false
     t.decimal  "client_hours",        precision: 4, scale: 2, default: 0.0,   null: false
     t.decimal  "internal_hours",      precision: 4, scale: 2, default: 0.0,   null: false
     t.datetime "created_at",                                                  null: false
@@ -31,21 +29,21 @@ ActiveRecord::Schema.define(version: 20150422171320) do
   end
 
   add_index "days", ["date"], name: "index_days_on_date", using: :btree
-  add_index "days", ["month_number"], name: "index_days_on_month_number", using: :btree
   add_index "days", ["user_id"], name: "index_days_on_user_id", using: :btree
-  add_index "days", ["week_number"], name: "index_days_on_week_number", using: :btree
 
   create_table "months", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.uuid     "user_id",                                              null: false
-    t.string   "number",                                               null: false
     t.decimal  "client_hours",   precision: 5, scale: 2, default: 0.0, null: false
     t.decimal  "internal_hours", precision: 5, scale: 2, default: 0.0, null: false
     t.datetime "created_at",                                           null: false
     t.datetime "updated_at",                                           null: false
+    t.integer  "year",                                                 null: false
+    t.integer  "number",                                               null: false
   end
 
   add_index "months", ["number"], name: "index_months_on_number", using: :btree
   add_index "months", ["user_id"], name: "index_months_on_user_id", using: :btree
+  add_index "months", ["year"], name: "index_months_on_year", using: :btree
 
   create_table "users", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string   "name",          null: false

--- a/spec/factories/months.rb
+++ b/spec/factories/months.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     end
 
     user
-    number { date.strftime("%Y%m") }
+    year { date.year }
+    number { date.month }
   end
 end

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -16,42 +16,6 @@ describe Day do
     end
   end
 
-  context "callbacks" do
-    describe "#set_month_number" do
-      it "sets the month number according to the date" do
-        day = build(:day, date: "2014-12-29") # Monday
-
-        expect {
-          day.save!
-        }.to change {
-          day.month_number
-        }.from(nil).to("201412")
-      end
-    end
-
-    describe "#set_week_number" do
-      it "sets the week-based year week number according to the date" do
-        day = build(:day, date: "2014-12-29") # Monday
-
-        expect {
-          day.save!
-        }.to change {
-          day.week_number
-        }.from(nil).to("201501")
-      end
-
-      it "considers Monday the start of the week" do
-        day = build(:day, date: "2014-12-28") # Sunday
-
-        expect {
-          day.save!
-        }.to change {
-          day.week_number
-        }.from(nil).to("201452")
-      end
-    end
-  end
-
   describe ".last_week" do
     it "returns days from last week (Monday-Sunday)" do
       create(:day, date: 2.weeks.ago.to_date.sunday)


### PR DESCRIPTION
Previously, Days stored a `month_number` and a `week_number`. This was pretty clever and identified the month and week that any given day belongs to. This allowed us to easily query days by month or week.

Well… it turns out that it's already easy to query by month or week by just querying a Day's `date` against  some date range. So this rips out some of the earlier cleverness.