### PR TITLE
Added time zone awareness for user alerts

### DIFF
--- a/app/interactors/send_timer_reminders.rb
+++ b/app/interactors/send_timer_reminders.rb
@@ -6,7 +6,7 @@ class SendTimerReminders
   end
 
   def call
-    User.for_timer_reminder(date: context.date).each do |user|
+    User.where(time_zone: context.time_zone).for_timer_reminder(date: context.date).each do |user|
       Notifier.timer_reminder(user).deliver_now
       user.timer_reminder_sent!(date: context.date)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,10 @@ class User < ActiveRecord::Base
     joins(:days).merge(Day.for_timer_reminder(date: date))
   end
 
+  def self.time_zones
+    pluck("DISTINCT time_zone")
+  end
+
   def timer_reminder_sent!(date: Date.current)
     days.find_by!(date: date).update!(timer_reminder_sent: true)
   end

--- a/lib/tasks/hourglass.rake
+++ b/lib/tasks/hourglass.rake
@@ -28,8 +28,10 @@ namespace :hourglass do
   desc "Send reminder emails to users who haven't started timers yet today"
   task :send_timer_reminders => :environment do
     # Weekdays on or after 10am
-    if Date.current.cwday <= 5 && Time.current.hour >= 10
-      SendTimerReminders.call!
+    User.time_zones.each do |tz|
+      if Date.current.cwday <= 5 && Time.current.in_time_zone(tz).hour >= 10
+        SendTimerReminders.call!(time_zone: tz)
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,4 +54,16 @@ describe User do
       it { is_expected.not_to accept_values_for(:time_zone, nil, "Foo Bar") }
     end
   end
+
+  context "scopes" do
+    describe "time_zones" do
+      it "returns an array of every unique time zone represented in the users table" do
+        create(:user, time_zone: "Cairo")
+        create(:user, time_zone: "Alaska")
+        create(:user, time_zone: "Alaska")
+
+        expect(User.time_zones).to eq(%w(Cairo Alaska))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR causes hourglass to use user time zones, so that it only sends a timer reminder to users who are after 10am in their timezone and have no logged hours.