### PR TITLE
Remove the unassigned entry and only show hours for assigned users

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -47,22 +47,13 @@ class Notifier < ActionMailer::Base
       memo
     end
 
-    @hours_by_user[:unassigned] = {
-      user_email: "unassigned",
-      user_hours: 0,
-      expected_hours: 0,
-    }
-
     @billed_hours = 0
     project_hours.each do |time_entry|
       details = @hours_by_user[time_entry.user_id]
       if details
         details[:user_hours] += time_entry.hours
-      else
-        @hours_by_user[:unassigned][:user_hours] += time_entry.hours
+        @billed_hours += time_entry.hours
       end
-
-      @billed_hours += time_entry.hours
     end
 
     mail to: team.users.map(&:email), subject: I18n.t("notifier.team_reminder.subject", team_name: @team.name)

--- a/spec/interactors/send_team_hours_update_spec.rb
+++ b/spec/interactors/send_team_hours_update_spec.rb
@@ -3,6 +3,7 @@ describe SendTeamHoursUpdate do
     team = create(:team, name: "Test Team", hours: 20, project_name: "Test Project")
     user_1 = create(:user, name: "Jason")
     user_2 = create(:user, name: "Chris")
+    user_3 = create(:user, email: "user3@test.com")
 
     team.assignments.create(user: user_1, hours: 10)
     team.assignments.create(user: user_2, hours: 10)
@@ -24,6 +25,7 @@ describe SendTeamHoursUpdate do
       [
         create(:harvest_time_entry, :client, hours: 1.0, user_id: user_1.harvest_id.to_i),
         create(:harvest_time_entry, :client, hours: 4.0, user_id: user_2.harvest_id.to_i),
+        create(:harvest_time_entry, :client, hours: 12.0),
       ]
     }
 
@@ -36,6 +38,11 @@ describe SendTeamHoursUpdate do
     expect(current_email).to have_subject(I18n.t("notifier.team_reminder.subject", team_name: "Test Team"))
 
     expect(current_email).to have_body_text("20 budgeted hours")
+
+    # Don't include details of users who have hours on the project
+    # that aren't members of the team
+    expect(current_email).to_not have_body_text("12")
+    expect(current_email).to_not have_body_text(user_3.email)
   end
 
 end


### PR DESCRIPTION
While the system does pull in all time entries for the given Harvest
project, the "unassigned" setup didn't really make much sense in
practice. Instead, we will only report on the hours for users who are
assigned, and will compare the team hours only to the combined hours of
assigned users.