### PR TITLE
Also send an email of how last week went for team hours

### DIFF
--- a/app/interactors/send_team_hours_update.rb
+++ b/app/interactors/send_team_hours_update.rb
@@ -3,8 +3,9 @@ class SendTeamHoursUpdate
   include HasHarvest
 
   def call
-    from = Date.this_week.first
-    to = Date.this_week.last
+    week = context.week || Date.this_week
+    from = week.first
+    to = week.last
 
     Team.active.each do |team|
       time_entries = harvest.reports.time_by_project(team.project_id, from, to, billable: true)

--- a/lib/tasks/hourglass.rake
+++ b/lib/tasks/hourglass.rake
@@ -49,7 +49,14 @@ namespace :hourglass do
   desc "Send report on current weekly team hours usage"
   task :team_hours_update => :environment do
     if Date.current.wednesday? || Date.current.friday?
-      SendTeamHoursUpdate.call!
+      SendTeamHoursUpdate.call!(week: Date.this_week)
+    end
+  end
+
+  desc "Send report on last wee's team hours usage"
+  task :last_week_team_hours => :environment do
+    if Date.current.monday?
+      SendTeamHoursUpdate.call!(week: Date.last_week)
     end
   end
 end

--- a/spec/interactors/send_team_hours_update_spec.rb
+++ b/spec/interactors/send_team_hours_update_spec.rb
@@ -1,8 +1,8 @@
 describe SendTeamHoursUpdate do
   it "sends an email to all team members of the current hours for the week" do
     team = create(:team, name: "Test Team", hours: 20, project_name: "Test Project")
-    user_1 = create(:user, name: "Jason")
-    user_2 = create(:user, name: "Chris")
+    user_1 = create(:user, name: "Jason", email: "jason@test.com")
+    user_2 = create(:user, name: "Chris", email: "chris@test.com")
     user_3 = create(:user, email: "user3@test.com")
 
     team.assignments.create(user: user_1, hours: 10)

--- a/spec/interactors/send_team_hours_update_spec.rb
+++ b/spec/interactors/send_team_hours_update_spec.rb
@@ -29,7 +29,7 @@ describe SendTeamHoursUpdate do
       ]
     }
 
-    SendTeamHoursUpdate.call
+    SendTeamHoursUpdate.call(week: Date.this_week)
 
     open_last_email_for(user_1.email)
     expect(current_email).to have_subject(I18n.t("notifier.team_reminder.subject", team_name: "Test Team"))


### PR DESCRIPTION
This should be sent early on Monday to let the team know how they did last week.
Having this information the team can then plan their next week accordingly.