### PR TITLE
Fix team hours email to pass the given date range to the mailer

### DIFF
--- a/app/interactors/send_team_hours_update.rb
+++ b/app/interactors/send_team_hours_update.rb
@@ -9,7 +9,7 @@ class SendTeamHoursUpdate
 
     Team.active.each do |team|
       time_entries = harvest.reports.time_by_project(team.project_id, from, to, billable: true)
-      Notifier.team_hours_update(team, time_entries).deliver_now
+      Notifier.team_hours_update(team, week, time_entries).deliver_now
     end
   end
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -35,8 +35,9 @@ class Notifier < ActionMailer::Base
     mail to: user.email
   end
 
-  def team_hours_update(team, project_hours)
+  def team_hours_update(team, week_range, project_hours)
     @team = team
+    @week_range = week_range
 
     @hours_by_user = @team.assignments.includes(:user).inject({}) do |memo, assignment|
       memo[assignment.user.harvest_id.to_i] = {

--- a/app/views/notifier/team_hours_update.html.erb
+++ b/app/views/notifier/team_hours_update.html.erb
@@ -17,7 +17,7 @@
       <tr>
         <td width="800px" height="180px" style="vertical-align: top;">
           <p>
-            For the week of <%= friendly_date_range(Date.this_week) %>, you have used <%= @billed_hours.round(2) %> of <%= @team.hours %> budgeted hours.
+            For the week of <%= friendly_date_range(@week_range) %>, you have used <%= @billed_hours.round(2) %> of <%= @team.hours %> budgeted hours.
           </p>
 
           <p>

--- a/app/views/notifier/team_hours_update.text.erb
+++ b/app/views/notifier/team_hours_update.text.erb
@@ -1,6 +1,6 @@
 <%= @team.name %> Team,
 
-For the week of <%= friendly_date_range(Date.this_week) %>, you have used <%= @billed_hours.round(2) %> of <%= @team.hours %> budgeted hours.
+For the week of <%= friendly_date_range(@week_range) %>, you have used <%= @billed_hours.round(2) %> of <%= @team.hours %> budgeted hours.
 
 <% @hours_by_user.each do |(_, details)| %>
 <%= details[:user_email] %> :: <%= details[:user_hours].round(2) %> / <%= details[:expected_hours].round(2) %>


### PR DESCRIPTION
The email was defaulting to This Week, ignoring any other range that was
passed into the interactor via a rake task.