### PR TITLE
Add the hourglass:weekly_report rake task

### DIFF
--- a/app/interactors/generate_report.rb
+++ b/app/interactors/generate_report.rb
@@ -1,9 +1,9 @@
-class GenerateMonthlyReport
+class GenerateReport
   include Interactor
 
   before do
     context.date ||= Date.current.last_month
-    context.range = context.date.all_month
+    context.range ||= context.date.all_month
 
     context.output = [
       "Email",

--- a/lib/tasks/hourglass.rake
+++ b/lib/tasks/hourglass.rake
@@ -41,9 +41,15 @@ namespace :hourglass do
   end
 
   desc "Generate a CSV time tracking report for a given month"
-  task :report, [:date] => :environment do |_, args|
+  task :monthly_report, [:date] => :environment do |_, args|
     date = args[:date] ? Date.parse(args[:date]) : Date.current.last_month
-    puts GenerateMonthlyReport.call!(date: date).output
+    puts GenerateReport.call!(range: date.all_month).output
+  end
+
+  desc "Generate a CSV time tracking report for a given week"
+  task :weekly_report, [:date] => :environment do |_, args|
+    date = args[:date] ? Date.parse(args[:date]) : Date.current.last_week
+    puts GenerateReport.call!(range: date.all_week).output
   end
 
   desc "Send report on current weekly team hours usage"


### PR DESCRIPTION
This repurposes the `GenerateMonthlyReport` interactor to be a generic `GenerateReport` interactor. Each rake task (`hourglass:monthly_report` and `hourglass:weekly_report`) call the same interactor with different date ranges.