### PR TITLE
Add the ability to tag users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,13 +14,12 @@ gem "pg"
 gem "puma"
 
 # Assets
-gem "bootstrap-chosen-rails"
 gem "bootstrap-sass"
-gem "chosen-rails"
 gem "coffee-rails"
 gem "font-awesome-rails"
 gem "jquery-rails"
 gem "sass-rails"
+gem "select2-rails"
 gem "uglifier"
 
 # Helper for dynamic jquery nested attributes forms

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,6 @@ GEM
     arel (6.0.4)
     autoprefixer-rails (7.1.1.2)
       execjs
-    bootstrap-chosen-rails (0.0.4)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -55,10 +54,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    chosen-rails (1.5.2)
-      coffee-rails (>= 3.2)
-      railties (>= 3.0)
-      sass-rails (>= 3.2)
     cliver (0.3.2)
     cocoon (1.2.10)
     codeclimate-test-reporter (1.0.8)
@@ -215,6 +210,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    select2-rails (4.0.3)
+      thor (~> 0.14)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -251,10 +248,8 @@ PLATFORMS
 
 DEPENDENCIES
   accept_values_for
-  bootstrap-chosen-rails
   bootstrap-sass
   capybara
-  chosen-rails
   cocoon
   codeclimate-test-reporter
   coffee-rails
@@ -281,6 +276,7 @@ DEPENDENCIES
   rails_12factor
   rspec-rails
   sass-rails
+  select2-rails
   timecop
   uglifier
   webmock

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require chosen-jquery
+//= require select2
 //= require cocoon
 //= require bootstrap/collapse
 //= require_tree .

--- a/app/assets/javascripts/chosen.js.coffee
+++ b/app/assets/javascripts/chosen.js.coffee
@@ -1,3 +1,0 @@
-$ ->
-  $(".chosen").chosen
-    width: "100%"

--- a/app/assets/javascripts/select2_init.js.coffee
+++ b/app/assets/javascripts/select2_init.js.coffee
@@ -1,0 +1,3 @@
+$ ->
+  $(".select2").select2
+    theme: "bootstrap"

--- a/app/assets/javascripts/teams.js.coffee
+++ b/app/assets/javascripts/teams.js.coffee
@@ -1,4 +1,4 @@
 $ ->
-  $("#assignments").on("cocoon:after-insert", (e, inserted) ->
-    $(".chosen", inserted).chosen(width: "100%")
-  )
+  $("#assignments").on "cocoon:after-insert", (_, inserted) ->
+    $(".select2", inserted).select2
+      theme: "bootstrap"

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,8 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "font-awesome";
-@import "chosen";
-@import "bootstrap-chosen";
+@import "select2";
+@import "select2-bootstrap";
 
 @import "global";
 @import "user_list";

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -1,19 +1,3 @@
 body {
   padding-bottom: 50px;
 }
-
-.chosen-container-multi {
-  .chosen-choices {
-    padding: 0 0 6px 6px;
-
-    .search-choice {
-      margin: 6px 6px 0 0 !important;
-    }
-
-    .search-field input {
-      margin: 6px 0 0 0 !important;
-      height: 21px !important;
-      line-height: 21px !important;
-    }
-  }
-}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,13 +43,13 @@ class UsersController < ApplicationController
 
   def user_attributes
     params.require(:user).permit(
-      :comma_separated_tags,
       :email,
       :harvest_id,
       :name,
       :slack_id,
       :time_zone,
       :zenefits_name,
+      tags: [],
       workdays: []
     )
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,6 +43,7 @@ class UsersController < ApplicationController
 
   def user_attributes
     params.require(:user).permit(
+      :comma_separated_tags,
       :email,
       :harvest_id,
       :name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,4 +41,12 @@ class User < ActiveRecord::Base
   def archive
     update!(active: false)
   end
+
+  def comma_separated_tags
+    tags.sort.join(", ")
+  end
+
+  def comma_separated_tags=(value)
+    self.tags = value.to_s.strip.split(/\s*,\s*/)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ActiveRecord::Base
     :pto_hours_for_date_range, to: :days
 
   scope :active, -> { where(active: true) }
+  scope :with_tags, -> (tags) { where("tags @> ARRAY[?]", tags) }
 
   def self.for_timer_reminder(date: Date.current)
     joins(:days).merge(Day.for_timer_reminder(date: date))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ActiveRecord::Base
   end
 
   def workdays=(values)
-    super(values.reject(&:blank?))
+    super(values.reject(&:blank?).sort)
   end
 
   def archive
@@ -50,6 +50,6 @@ class User < ActiveRecord::Base
   end
 
   def tags=(values)
-    super(values.reject(&:blank?))
+    super(values.reject(&:blank?).sort)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,10 @@ class User < ActiveRecord::Base
     :pto_hours_for_date_range, to: :days
 
   scope :active, -> { where(active: true) }
-  scope :with_tags, -> (tags) { where("tags @> ARRAY[?]", tags) }
+
+  def self.with_tags(tags)
+    tags.any? ? where("tags && ARRAY[?]", tags) : all
+  end
 
   def self.for_timer_reminder(date: Date.current)
     joins(:days).merge(Day.for_timer_reminder(date: date))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,10 @@ class User < ActiveRecord::Base
     pluck("DISTINCT time_zone")
   end
 
+  def self.tags
+    order("tag ASC").pluck("DISTINCT UNNEST(tags) AS tag")
+  end
+
   def timer_reminder_sent!(date: Date.current)
     days.find_by!(date: date).update!(timer_reminder_sent: true)
   end
@@ -42,11 +46,7 @@ class User < ActiveRecord::Base
     update!(active: false)
   end
 
-  def comma_separated_tags
-    tags.sort.join(", ")
-  end
-
-  def comma_separated_tags=(value)
-    self.tags = value.to_s.strip.split(/\s*,\s*/)
+  def tags=(values)
+    super(values.reject(&:blank?))
   end
 end

--- a/app/views/teams/_assignment_fields.html.erb
+++ b/app/views/teams/_assignment_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="assignment-row row nested-fields">
   <div class="col-xs-8 form-group">
     <%= f.label :user_id, class: "control-label" %>
-    <%= f.collection_select :user_id, users, :id, :email, {prompt: true}, {data: "user_select", class: "form-control chosen"} %>
+    <%= f.collection_select :user_id, users, :id, :email, { prompt: true }, data: "user_select", class: "form-control select2" %>
   </div>
   <div class="col-xs-2 form-group">
     <%= f.label :hours, class: "control-label" %>
@@ -9,6 +9,6 @@
   </div>
   <div class="col-xs-2 form-group">
     <label class="invisible">Remove</label>
-    <%= link_to_remove_association fa_icon("trash"), f, {class: "btn btn-danger"} %>
+    <%= link_to_remove_association fa_icon("trash"), f, class: "btn btn-danger" %>
   </div>
 </div>

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -5,7 +5,7 @@
 
 <div class="form-group">
   <%= form.label :project_id, class: "control-label" %>
-  <%= form.grouped_collection_select :project_id, harvest_projects, :last, :first, :id, :name, { prompt: true }, { class: "form-control chosen" } %>
+  <%= form.grouped_collection_select :project_id, harvest_projects, :last, :first, :id, :name, { prompt: true }, { class: "form-control select2" } %>
 </div>
 
 <div class="form-group">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -33,5 +33,9 @@
   <%= form.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones, { default: Time.zone.name }, class: "form-control chosen" %>
 </div>
 <div class="form-group">
+  <%= form.label :comma_separated_tags, class: "control-label" %>
+  <%= form.text_field :comma_separated_tags, class: "form-control", placeholder: "design, development" %>
+</div>
+<div class="form-group">
   <%= button_tag fa_icon("check", text: "Save User"), class: "btn btn-block btn-lg btn-primary", data: { disable: true } %>
 </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -25,16 +25,16 @@
 </div>
 <div class="form-group">
   <%= form.label :workdays, class: "control-label" %>
-  <%= form.select :workdays, [["Mon", 1], ["Tue", 2], ["Wed", 3], ["Thu", 4], ["Fri", 5], ["Sat", 6], ["Sun", 7]], {}, multiple: true, class: "form-control chosen", size: 7, data: { placeholder: "Select Days of the Week" } %>
+  <%= form.select :workdays, [["Mon", 1], ["Tue", 2], ["Wed", 3], ["Thu", 4], ["Fri", 5], ["Sat", 6], ["Sun", 7]], {}, multiple: true, class: "form-control select2", size: 7, data: { placeholder: "Select Days of the Week" } %>
   <p class="help-block">Days (excluding PTO) this user is expected to work.</p>
 </div>
 <div class="form-group">
   <%= form.label :time_zone, class: "control-label" %>
-  <%= form.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones, { default: Time.zone.name }, class: "form-control chosen" %>
+  <%= form.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones, { default: Time.zone.name }, class: "form-control select2" %>
 </div>
 <div class="form-group">
-  <%= form.label :comma_separated_tags, class: "control-label" %>
-  <%= form.text_field :comma_separated_tags, class: "form-control", placeholder: "design, development" %>
+  <%= form.label :tags, class: "control-label" %>
+  <%= form.select :tags, User.tags, {}, class: "form-control select2", multiple: true, data: { placeholder: "design, development", tags: true } %>
 </div>
 <div class="form-group">
   <%= button_tag fa_icon("check", text: "Save User"), class: "btn btn-block btn-lg btn-primary", data: { disable: true } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
   activerecord:
     attributes:
       user:
+        comma_separated_tags: "Tags"
         email: "Email Address"
         harvest_id: "Harvest ID"
         name: "Name"

--- a/db/migrate/20170618001302_add_tags_to_users.rb
+++ b/db/migrate/20170618001302_add_tags_to_users.rb
@@ -1,0 +1,6 @@
+class AddTagsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :tags, :text, array: true, default: []
+    add_index :users, :tags, using: "gin"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161002200246) do
+ActiveRecord::Schema.define(version: 20170618001302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,8 +81,10 @@ ActiveRecord::Schema.define(version: 20161002200246) do
     t.string   "slack_id"
     t.string   "workdays",      default: ["1", "2", "3", "4", "5"], null: false, array: true
     t.boolean  "active",        default: true,                      null: false
+    t.text     "tags",          default: [],                                     array: true
   end
 
   add_index "users", ["slack_id"], name: "index_users_on_slack_id", unique: true, using: :btree
+  add_index "users", ["tags"], name: "index_users_on_tags", using: :gin
 
 end

--- a/lib/tasks/hourglass.rake
+++ b/lib/tasks/hourglass.rake
@@ -44,7 +44,8 @@ namespace :hourglass do
   task :monthly_report, [:date] => :environment do |_, args|
     Rails.logger.silence do
       date = args[:date] ? Date.parse(args[:date]) : Date.current.last_month
-      puts GenerateReport.call!(range: date.all_month).output
+      tags = (ENV["TAGS"] || ENV["TAG"]).to_s.split(",")
+      puts GenerateReport.call!(range: date.all_month, tags: tags).output
     end
   end
 
@@ -52,7 +53,8 @@ namespace :hourglass do
   task :weekly_report, [:date] => :environment do |_, args|
     Rails.logger.silence do
       date = args[:date] ? Date.parse(args[:date]) : Date.current.last_week
-      puts GenerateReport.call!(range: date.all_week).output
+      tags = (ENV["TAGS"] || ENV["TAG"]).to_s.split(",")
+      puts GenerateReport.call!(range: date.all_week, tags: tags).output
     end
   end
 

--- a/lib/tasks/hourglass.rake
+++ b/lib/tasks/hourglass.rake
@@ -41,18 +41,18 @@ namespace :hourglass do
   end
 
   desc "Generate a CSV time tracking report for a given month"
-  task :monthly_report, [:date] => :environment do |_, args|
+  task :monthly_report => :environment do
     Rails.logger.silence do
-      date = args[:date] ? Date.parse(args[:date]) : Date.current.last_month
+      date = ENV["DATE"] ? Date.parse(ENV["DATE"]) : Date.current.last_month
       tags = (ENV["TAGS"] || ENV["TAG"]).to_s.split(",")
       puts GenerateReport.call!(range: date.all_month, tags: tags).output
     end
   end
 
   desc "Generate a CSV time tracking report for a given week"
-  task :weekly_report, [:date] => :environment do |_, args|
+  task :weekly_report => :environment do
     Rails.logger.silence do
-      date = args[:date] ? Date.parse(args[:date]) : Date.current.last_week
+      date = ENV["DATE"] ? Date.parse(ENV["DATE"]) : Date.current.last_week
       tags = (ENV["TAGS"] || ENV["TAG"]).to_s.split(",")
       puts GenerateReport.call!(range: date.all_week, tags: tags).output
     end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,6 +1,6 @@
 feature "Users" do
-  let!(:jack) { create(:user, name: "Jack", email: "jack@example.com") }
-  let!(:jill) { create(:user, name: "Jill", email: "jill@example.com") }
+  let!(:jack) { create(:user, name: "Jack", email: "jack@example.com", tags: %w(local design)) }
+  let!(:jill) { create(:user, name: "Jill", email: "jill@example.com", tags: %w(remote development)) }
 
   scenario "A visitor can see a list of all users" do
     visit users_path
@@ -30,7 +30,8 @@ feature "Users" do
       zenefits_name: "Jane Doe",
       time_zone: "Eastern Time (US & Canada)",
       slack_id: "738YDH2IZJ",
-      workdays: %w(Mon Tue Wed Thu)
+      workdays: %w(Mon Tue Wed Thu),
+      tags: %w(local development)
     )
     dom_user_form.submit
 
@@ -53,6 +54,7 @@ feature "Users" do
     expect(jane.time_zone).to eq("Eastern Time (US & Canada)")
     expect(jane.slack_id).to eq("738YDH2IZJ")
     expect(jane.workdays).to eq(%w(1 2 3 4))
+    expect(jane.tags).to match_array(%w(local development))
   end
 
   scenario "A visitor can update a user" do

--- a/spec/interactors/send_team_hours_update_spec.rb
+++ b/spec/interactors/send_team_hours_update_spec.rb
@@ -45,9 +45,9 @@ describe SendTeamHoursUpdate do
 
     expect(current_email).to have_body_text(friendly_date_range(time_range))
 
-    # Don't include details of users who have hours on the project
-    # that aren't members of the team
-    expect(current_email).to_not have_body_text("12")
+    # Don't include details of users who have hours on the project that aren't
+    # members of the team.
+    expect(current_email).to_not have_body_text("12.0")
     expect(current_email).to_not have_body_text(user_3.email)
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,15 +55,23 @@ describe User do
     end
   end
 
-  context "scopes" do
-    describe "time_zones" do
-      it "returns an array of every unique time zone represented in the users table" do
-        create(:user, time_zone: "Cairo")
-        create(:user, time_zone: "Alaska")
-        create(:user, time_zone: "Alaska")
+  describe ".time_zones" do
+    it "returns an array of every unique time zone represented in the users table" do
+      create(:user, time_zone: "Cairo")
+      create(:user, time_zone: "Alaska")
+      create(:user, time_zone: "Alaska")
 
-        expect(User.time_zones).to eq(%w(Cairo Alaska))
-      end
+      expect(User.time_zones).to eq(%w(Cairo Alaska))
+    end
+  end
+
+  describe ".tags" do
+    it "returns a sorted array of every unique tag represented in the users table" do
+      create(:user, tags: %w(foo bar))
+      create(:user, tags: %w(foo baz))
+      create(:user, tags: [])
+
+      expect(User.tags).to eq(%w(bar baz foo))
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,6 +55,31 @@ describe User do
     end
   end
 
+  describe ".with_tags" do
+    it "returns users with any of the provided tags" do
+      user_1 = create(:user, tags: %w(foo bar))
+      user_2 = create(:user, tags: %w(foo baz))
+      user_3 = create(:user, tags: %w(hello world))
+      user_4 = create(:user, tags: [])
+
+      users = User.with_tags(%w(hello baz))
+
+      expect(users).to include(user_2, user_3)
+      expect(users).not_to include(user_1, user_4)
+    end
+
+    it "returns all users if no tags are provided" do
+      user_1 = create(:user, tags: %w(foo bar))
+      user_2 = create(:user, tags: %w(foo baz))
+      user_3 = create(:user, tags: %w(hello world))
+      user_4 = create(:user, tags: [])
+
+      users = User.with_tags([])
+
+      expect(users).to include(user_1, user_2, user_3, user_4)
+    end
+  end
+
   describe ".time_zones" do
     it "returns an array of every unique time zone represented in the users table" do
       create(:user, time_zone: "Cairo")

--- a/spec/support/domino.rb
+++ b/spec/support/domino.rb
@@ -180,10 +180,10 @@ module DOM
     def add_user(email:, hours:)
       click_link "Add Assignment"
 
-      select = page.find_field("User", visible: :hidden)
-      chosen = page.find(:xpath, "#{select.path}/following-sibling::div[contains(@class, 'chosen-container')]")
-      chosen.click
-      chosen.find(".chosen-results li", text: email).click
+      select = page.find_field("User")
+      select2 = select.find(:xpath, "..").find(".select2-container")
+      select2.click
+      page.find(".select2-results li", text: email).click
 
       node.fill_in("Hours", with: hours)
     end

--- a/spec/support/domino.rb
+++ b/spec/support/domino.rb
@@ -101,6 +101,15 @@ module DOM
       workdays.each { |w| node.select(w, from: "Scheduled Workdays") }
     end
 
+    def tags
+      node.find_field("Tags").all("option").select(&:selected?).map(&:text)
+    end
+
+    def tags=(tags)
+      self.tags.each { |t| node.unselect(t, from: "Tags") }
+      tags.each { |t| node.select(t, from: "Tags") }
+    end
+
     def set(attributes)
       attributes.each do |key, value|
         send("#{key}=", value)


### PR DESCRIPTION
This allows us to customize our monthly and weekly reports, scoping them to a subset of users based on tag. Tags could include project team or department.

## Demo

![demo](https://user-images.githubusercontent.com/34264/27263983-45cde482-5443-11e7-9873-477b0d2bdf19.gif)

## To-Do

- [x] Write unit tests for `User.tags`
- [x] Write unit tests for `User.with_tags`
- [x] Write a feature test for saving tags
